### PR TITLE
Expose settings into a header that doesn't include impl file.

### DIFF
--- a/mapmap/header/instance_factory.h
+++ b/mapmap/header/instance_factory.h
@@ -14,17 +14,11 @@
 #include <mapmap/header/graph.h>
 
 #include <mapmap/header/tree_sampler.h>
+#include <mapmap/header/settings.h>
 
 #include <memory>
 
 NS_MAPMAP_BEGIN
-
-/* 0s mark the default algorithm */
-enum TREE_SAMPLER_ALGORITHM
-{
-    OPTIMISTIC_TREE_SAMPLER = 0,
-    LOCK_FREE_TREE_SAMPLER = 1
-};
 
 /* ************************************************************************** */
 

--- a/mapmap/header/mapmap.h
+++ b/mapmap/header/mapmap.h
@@ -27,6 +27,7 @@
 #include <mapmap/header/tree.h>
 #include <mapmap/header/tree_optimizer.h>
 #include <mapmap/header/instance_factory.h>
+#include <mapmap/header/settings.h>
 
 #include <oneapi/tbb/tick_count.h>
 
@@ -50,9 +51,6 @@ const char * const UNIX_COLOR_PINK = "\033[1;35m";
 const char * const UNIX_COLOR_YELLOW = "\033[1;33m";
 const char * const UNIX_COLOR_WHITE = "\033[1;37m";
 const char * const UNIX_COLOR_RESET = "\033[0m";
-
-/* forward declarations */
-struct mapMAP_control;
 
 /* MAPMAP main class */
 template<typename COSTTYPE, uint_t SIMDWIDTH>
@@ -183,36 +181,6 @@ protected:
     bool m_use_callback;
     std::function<void (const luint_t, const _s_t<COSTTYPE, SIMDWIDTH>)>
         m_callback;
-};
-
-/**
- * control flow struct (default values for flowgraph in paper)
- *
- * NOTE: despite settings concerning minimum iteration numbers, early
- * termination may be forced by a user-defined termination criterion
- */
-struct mapMAP_control
-{
-    /* switch modes on/off */
-    bool use_multilevel;
-    bool use_spanning_tree;
-    bool use_acyclic;
-
-    /* multilevel settings */
-    /* none */
-
-    /* spanning tree settings */
-    uint_t spanning_tree_multilevel_after_n_iterations;
-
-    /* acyclic settings */
-    bool force_acyclic; /* force using acyclic even if terminated */
-    uint_t min_acyclic_iterations;
-    bool relax_acyclic_maximal;
-
-    /* settings for tree sampling */
-    TREE_SAMPLER_ALGORITHM tree_algorithm;
-    bool sample_deterministic;
-    uint_t initial_seed;
 };
 
 NS_MAPMAP_END

--- a/mapmap/header/settings.h
+++ b/mapmap/header/settings.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2016, Daniel Thuerck
+ * TU Darmstadt - Graphics, Capture and Massively Parallel Computing
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the BSD license. See the LICENSE file for details.
+ */
+
+#ifndef __MAPMAP_MAPMAP_SETTINGS_H_
+#define __MAPMAP_MAPMAP_SETTINGS_H_
+
+#include <mapmap/header/defines.h>
+#include <mapmap/header/vector_types.h>
+
+NS_MAPMAP_BEGIN
+
+/* 0s mark the default algorithm */
+enum TREE_SAMPLER_ALGORITHM
+{
+    OPTIMISTIC_TREE_SAMPLER = 0,
+    LOCK_FREE_TREE_SAMPLER = 1
+};
+
+/**
+ * control flow struct (default values for flowgraph in paper)
+ *
+ * NOTE: despite settings concerning minimum iteration numbers, early
+ * termination may be forced by a user-defined termination criterion
+ */
+struct mapMAP_control
+{
+    /* switch modes on/off */
+    bool use_multilevel;
+    bool use_spanning_tree;
+    bool use_acyclic;
+
+    /* multilevel settings */
+    /* none */
+
+    /* spanning tree settings */
+    uint_t spanning_tree_multilevel_after_n_iterations;
+
+    /* acyclic settings */
+    bool force_acyclic; /* force using acyclic even if terminated */
+    uint_t min_acyclic_iterations;
+    bool relax_acyclic_maximal;
+
+    /* settings for tree sampling */
+    TREE_SAMPLER_ALGORITHM tree_algorithm;
+    bool sample_deterministic;
+    uint_t initial_seed;
+};
+
+NS_MAPMAP_END
+
+#endif /* __MAPMAP_MAPMAP_SETTINGS_H_ */


### PR DESCRIPTION
To avoid link errors, having twice the implementation included.